### PR TITLE
Add step2 for kubernetes

### DIFF
--- a/3. Kubernetes/step2/Pulumi.yaml
+++ b/3. Kubernetes/step2/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: qcon
+runtime: nodejs
+description: A minimal Kubernetes TypeScript Pulumi program

--- a/3. Kubernetes/step2/frontend.ts
+++ b/3. Kubernetes/step2/frontend.ts
@@ -1,0 +1,78 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as k8s from "@pulumi/kubernetes";
+import { Redis } from "./redis";
+
+export class Frontend extends pulumi.ComponentResource {
+    public readonly host: pulumi.Output<string>;
+
+    constructor(name: string, args: FrontendArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("qcon:frontend:Frontend", name, args, opts);
+        const labels = { app: "guestbook", tier: "frontend" };
+        const childOpts = { ...opts, parent: this };
+        const deployment = new k8s.apps.v1.Deployment(`${name}-deployment`, {
+            metadata: {
+                namespace: args.namespace,
+            },
+            spec: {
+                selector: {
+                    matchLabels: labels,
+                },
+                replicas: args.replicas || 2,
+                template: {
+                    metadata: {
+                        namespace: args.namespace,
+                        labels: labels,
+                    },
+                    spec: {
+                        containers: [{
+                            name: "php-redis",
+                            image: "gcr.io/google-samples/gb-frontend:v4",
+                            resources: {
+                                requests: {
+                                    cpu: "100m",
+                                    memory: "100Mi"
+                                }
+                            },
+                            env: [
+                                {
+                                    name: "GET_HOSTS_FROM",
+                                    value: "env",
+                                },
+                                {
+                                    name: "REDIS_MASTER_SERVICE_HOST",
+                                    value: args.redis.master.host,
+                                },
+                                {
+                                    name: "REDIS_SLAVE_SERVICE_HOST",
+                                    value: args.redis.replica.host,
+                                }
+                            ],
+                            ports: [{ containerPort: 80 }],
+                        }]
+                    }
+                }
+            }
+        }, childOpts);
+
+        const svc = new k8s.core.v1.Service(`${name}-svc`, {
+            metadata: {
+                namespace: args.namespace,
+                labels: labels,
+            },
+            spec: {
+                type: "LoadBalancer",
+                ports: [{ port: 80 }],
+                selector: labels,
+            },
+        }, childOpts);
+
+        this.host = svc.status.apply(status => status.loadBalancer.ingress[0].ip);
+        this.registerOutputs({});
+    }
+}
+
+export interface FrontendArgs {
+    namespace: pulumi.Input<string>;
+    redis: Redis;
+    replicas?: pulumi.Input<number>;
+}

--- a/3. Kubernetes/step2/index.ts
+++ b/3. Kubernetes/step2/index.ts
@@ -1,0 +1,19 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as k8s from "@pulumi/kubernetes";
+
+import { Redis } from "./redis";
+import { Frontend } from "./frontend";
+
+const namespace = new k8s.core.v1.Namespace("qcon");
+export const namespaceName = namespace.metadata.apply(meta => meta.name);
+const redis = new Redis("redis", {
+    namespace: namespaceName,
+    app: "redis",
+    tier: "backend",
+});
+const frontend = new Frontend("frontend", {
+    namespace: namespaceName,
+    redis: redis,
+});
+
+export const frontendUrl = pulumi.concat("http://", frontend.host);

--- a/3. Kubernetes/step2/package.json
+++ b/3. Kubernetes/step2/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "kubernetes-typescript",
+    "devDependencies": {
+        "@types/node": "latest"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "latest",
+        "@pulumi/kubernetes": "latest"
+    }
+}

--- a/3. Kubernetes/step2/redis.ts
+++ b/3. Kubernetes/step2/redis.ts
@@ -1,0 +1,152 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as k8s from "@pulumi/kubernetes";
+
+export class RedisMaster extends pulumi.ComponentResource {
+    public readonly host: pulumi.Output<string>;
+
+    constructor(name: string, args: RedisMasterArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("qcon:redis:Master", name, args, opts);
+        const childOpts = { ...opts, parent: this };
+        const labels = pulumi.output(args).apply(args => ({
+            app: args.app,
+            tier: args.tier,
+            role: "master",
+        }));
+        const masterDeployment = new k8s.apps.v1.Deployment(`${name}-master-deploy`, {
+            metadata: {
+                namespace: args.namespace,
+                labels: labels,
+            },
+            spec: {
+                selector: {
+                    matchLabels: labels,
+                },
+                template: {
+                    metadata: {
+                        labels: labels,
+                    },
+                    spec: {
+                        containers: [{
+                            name: "master",
+                            image: "k8s.gcr.io/redis:e2e",
+                            resources: { requests: { cpu: "100m", memory: "100Mi" } },
+                            ports: [{ containerPort: 6379 }]
+                        }]
+                    }
+                }
+            }
+        }, childOpts);
+        const masterService = new k8s.core.v1.Service(`${name}-master-svc`, {
+            metadata: {
+                namespace: args.namespace,
+                labels: masterDeployment.metadata.apply(meta => meta.labels),
+            },
+            spec: {
+                type: "ClusterIP",
+                ports: [{ port: 6379, targetPort: 6379 }],
+                selector: masterDeployment.spec.apply(spec => spec.template.metadata.labels),
+            }
+        }, childOpts);
+
+        this.host = masterService.spec.apply(spec => spec.clusterIP);
+        this.registerOutputs({});
+    }
+}
+
+export interface RedisMasterArgs {
+    namespace: pulumi.Input<string>;
+    app: pulumi.Input<string>;
+    tier: pulumi.Input<string>;
+}
+
+export class RedisReplica extends pulumi.ComponentResource {
+    public readonly host: pulumi.Output<string>;
+
+    constructor(name: string, args: RedisReplicaArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("qcon:redis:Replica", name, args, opts);
+        const childOpts = { ...opts, parent: this };
+        const labels = pulumi.output(args).apply(args => ({
+            app: args.app,
+            tier: args.tier,
+            role: "slave",
+        }));
+        const deployment = new k8s.apps.v1.Deployment(`${name}-replica-deployment`, {
+            metadata: {
+                namespace: args.namespace,
+            },
+            spec: {
+                selector: {
+                    matchLabels: labels,
+                },
+                template: {
+                    metadata: {
+                        labels: labels,
+                    },
+                    spec: {
+                        containers: [{
+                            name: "replica",
+                            image: "gcr.io/google_samples/gb-redisslave:v1",
+                            resources: { requests: { cpu: "100m", memory: "100Mi" } },
+                            // If your cluster config does not include a dns service, then to instead access an environment
+                            // variable to find the master service's host, change `value: "dns"` to read `value: "env"`.
+                            env: [
+                                { name: "GET_HOSTS_FROM", value: "env" },
+                                { name: "REDIS_MASTER_SERVICE_HOST", value: args.master.host },
+                            ],
+                            ports: [{ containerPort: 6379 }]
+                        }]
+                    }
+                }
+            }
+        }, childOpts);
+        const svc = new k8s.core.v1.Service(`${name}-replica-svc`, {
+            metadata: {
+                namespace: args.namespace,
+                labels: deployment.metadata.apply(meta => meta.labels),
+            },
+            spec: {
+                type: "ClusterIP",
+                ports: [{ port: 6379, targetPort: 6379 }],
+                selector: deployment.spec.apply(spec => spec.template.metadata.labels),
+            },
+        }, childOpts);
+
+        this.host = svc.spec.apply(spec => spec.clusterIP);
+        this.registerOutputs({});
+    }
+}
+
+export interface RedisReplicaArgs {
+    namespace: pulumi.Input<string>;
+    master: RedisMaster;
+    app: pulumi.Input<string>;
+    tier: pulumi.Input<string>;
+}
+
+export class Redis extends pulumi.ComponentResource {
+    public readonly master: RedisMaster;
+    public readonly replica: RedisReplica;
+
+    constructor(name: string, args: RedisArgs, opts?: pulumi.ComponentResourceOptions) {
+        super("qcon:redis:Redis", name, {}, opts);
+        const childOpts = { ...opts, parent: this };
+        this.master = new RedisMaster(name, {
+            namespace: args.namespace,
+            app: args.app,
+            tier: args.tier,
+        }, childOpts);
+        this.replica = new RedisReplica(name, {
+            namespace: args.namespace,
+            master: this.master,
+            app: args.app,
+            tier: args.tier,
+        }, childOpts);
+        this.registerOutputs({});
+    }
+}
+
+export interface RedisArgs {
+    namespace: pulumi.Input<string>;
+    app: pulumi.Input<string>;
+    tier: pulumi.Input<string>;
+}

--- a/3. Kubernetes/step2/tsconfig.json
+++ b/3. Kubernetes/step2/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
This is the "goal state" of the Kubernetes workshop, where we build up the Guestbook example using components. It deploys two Redis instances, a primary and a replica, as well as a PHP-based frontend that sends writes to the primary Redis instance and reads to the replica.

This is kind of a lot of code, so I haven't fully convinced myself that this is a good goal state. I do think it illustrates a good message, though: "you can separate concerns in your infrastructure code by encapsulating their details within components". This is especially true in the `Redis` component resource, which itself is composed of two component resources, `RedisMaster` and `RedisReplica`, which together form a replicated Redis cluster.

I plan to work backwards from this example to a step 1, as well as work forwards to "Kubernetes + Cloud" by replacing the `Redis` component with AWS ElastiCache.